### PR TITLE
chore: unify spacing and navigation styles

### DIFF
--- a/modules/profile/profile.css
+++ b/modules/profile/profile.css
@@ -248,7 +248,7 @@
 .stack-category-icon {
   width: 40px;
   height: 40px;
-  border-radius: 10px;
+  border-radius: var(--border-radius);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -284,7 +284,7 @@
 .stack-title {
   font-size: var(--font-size-base);
   font-weight: 600;
-  margin: 0 0 4px 0;
+  margin: 0 0 var(--space-xs) 0;
   color: var(--text-color);
   line-height: 1.2;
   overflow: hidden;
@@ -296,15 +296,15 @@
 
 .stack-category-badge {
   display: inline-block;
-  background: rgba(0, 122, 204, 0.1);
+  background: var(--primary-color-transparent);
   color: var(--primary-color);
-  padding: 2px 10px;
-  border-radius: 10px;
-  font-size: 11px;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  border: 1px solid rgba(0, 122, 204, 0.2);
+  border: 1px solid var(--primary-color-border);
   line-height: 1.2;
 }
 
@@ -346,7 +346,7 @@
 .stack-tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--space-xs);
   margin-bottom: var(--space-md);
   flex-grow: 1;
   align-content: flex-start;
@@ -356,9 +356,9 @@
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
   color: var(--text-light);
-  padding: 3px 8px;
-  border-radius: 12px;
-  font-size: 11px;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-xs);
   font-weight: 500;
   transition: all 0.2s ease;
   white-space: nowrap;
@@ -383,7 +383,7 @@
 .stat-item {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-xs);
   flex: 1;
 }
 

--- a/shared/css/base.css
+++ b/shared/css/base.css
@@ -164,7 +164,7 @@ pre code {
 /* Container */
 .container {
   max-width: var(--max-width);
-  margin: 8px auto;
+  margin: var(--space-sm) auto;
   padding: 0 var(--space-lg);
 }
 

--- a/shared/css/navigation-fix.css
+++ b/shared/css/navigation-fix.css
@@ -28,7 +28,7 @@
   color: var(--text-light);
   text-decoration: none;
   font-weight: 500;
-  border-radius: 8px;
+  border-radius: var(--border-radius);
   transition: all 0.2s ease;
   position: relative;
 }
@@ -40,7 +40,7 @@
 
 .nav-item.active {
   color: var(--primary-color);
-  background: rgba(0, 122, 204, 0.1);
+  background: var(--primary-color-transparent);
 }
 
 .nav-item svg {

--- a/shared/css/variables.css
+++ b/shared/css/variables.css
@@ -5,6 +5,8 @@
 :root {
   /* Basis-Farben */
   --primary-color: #007acc;
+  --primary-color-transparent: rgba(0, 122, 204, 0.1);
+  --primary-color-border: rgba(0, 122, 204, 0.2);
   --text-color: #333;
   --text-light: #666;
   --text-muted: #999;
@@ -47,6 +49,7 @@
   
   /* Typography */
   --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-size-xs: 0.75rem;
   --font-size-sm: 0.875rem;
   --font-size-base: 1rem;
   --font-size-lg: 1.125rem;


### PR DESCRIPTION
## Summary
- add reusable color and font-size tokens
- align container spacing to design scale
- clean up navigation and profile styles to use shared variables

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899bb3d29d0832980010ef2f117e730